### PR TITLE
Add initial frontend for translation feature

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Workers AI ハンズオン</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@exampledev/new.css@1.1.3/new.min.css" />
+  <link rel="stylesheet" href="style.css" />
+  <script src="script.js" defer></script>
+</head>
+
+<body>
+  <textarea id="prompt" placeholder="日本語を入力してください"></textarea>
+  <button id="translate-btn">
+    英語に翻訳
+  </button>
+  <p id="translate-error-message" class="error-message"></p>
+  <textarea id="translated-prompt" placeholder="ここに英語の翻訳結果が表示されます"></textarea>
+</body>
+
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,34 @@
+const translateBtn = document.getElementById("translate-btn");
+translateBtn.addEventListener("click", translateText);
+
+async function translateText() {
+  const errorMessage = document.getElementById("translate-error-message");
+  const promptInput = document.getElementById("prompt");
+
+  translateBtn.disabled = true;
+  errorMessage.style.display = "none";
+  const formData = new FormData();
+  formData.set("prompt", promptInput.value);
+
+  try {
+    const response = await fetch(`/translate`, {
+      method: "POST",
+      body: formData,
+    });
+
+    // if (!response.ok) {
+    //   throw new Error(`エラー ${response.status} ${response.statusText}`);
+    // }
+    verifyResponse(response);
+
+
+    const translatedPrompt = document.getElementById("translated-prompt");
+    await handleEventStream(response, translatedPrompt);
+  } catch (error) {
+    console.error("エラー: ", error);
+    errorMessage.textContent = "翻訳に失敗しました。もう一度試してください。";
+    errorMessage.style.display = "block";
+  } finally {
+    translateBtn.disabled = false;
+  }
+}

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,8 @@
+textarea {
+  width: 100%;
+  field-sizing: content;
+}
+
+.error-message {
+  color: red;
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,7 @@
 name = "cf-workers-hono-spa"
 main = "src/index.ts"
 compatibility_date = "2024-11-29"
+assets = { directory = "public"}
 
 # compatibility_flags = [ "nodejs_compat" ]
 


### PR DESCRIPTION
## Add initial frontend for translation feature

### Changes:
- **HTML**: Added `index.html` with basic structure for the translation UI, including:
  - A textarea for Japanese input.
  - A button to trigger translation.
  - An error message placeholder.
  - A textarea to display the English translation.
- **CSS**: Added `style.css` for basic styling:
  - Full-width textareas.
  - Red-colored error message styling.
- **JavaScript**: Added `script.js` with logic to:
  - Handle button clicks for triggering translation.
  - Send input data to the `/translate` endpoint.
  - Display the translation result or error message dynamically.
- **Wrangler Configuration**:
  - Updated `wrangler.toml` to include `public` directory as the assets folder for static files.

### Purpose:
This commit introduces the foundational frontend for the translation feature, enabling users to input text in Japanese and receive translations in English. The structure is prepared for further styling and backend integration.
